### PR TITLE
Subscription Schedule create sets the customer on the subscription co…

### DIFF
--- a/lib/stripe_mock/request_handlers/subscription_schedules.rb
+++ b/lib/stripe_mock/request_handlers/subscription_schedules.rb
@@ -25,7 +25,9 @@ module StripeMock
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)
         end
 
-        subscription = Data.mock_subscription({id: "sub_id"})
+        subscription = Data.mock_subscription({ id: (params[:id] || new_id('su')), customer: customer_id })
+        subscriptions[subscription[:id]] = subscription
+        add_subscription_to_customer(customer, subscription)
 
         sub_sched = Data.mock_subscription_schedule({
           id: (params[:id] || new_id('sub_sched')),

--- a/spec/shared_stripe_examples/subscription_schedule_examples.rb
+++ b/spec/shared_stripe_examples/subscription_schedule_examples.rb
@@ -17,7 +17,7 @@ shared_examples 'Subscription Schedule API' do
       expect(subscriptions.data).to be_empty
       expect(subscriptions.count).to eq(0)
 
-      sub = Stripe::SubscriptionSchedule.create({
+      subscription_schedule = Stripe::SubscriptionSchedule.create({
         customer: customer.id,
         start_date: Time.now.to_i,
         end_behavior: 'cancel',
@@ -32,9 +32,18 @@ shared_examples 'Subscription Schedule API' do
         ],
       })
 
-      expect(sub.object).to eq('subscription_schedule')
-      expect(sub.customer).to eq(customer.id)
-      expect(sub.end_behavior).to eq('cancel')
+      expect(subscription_schedule.object).to eq('subscription_schedule')
+      expect(subscription_schedule.customer).to eq(customer.id)
+      expect(subscription_schedule.end_behavior).to eq('cancel')
+
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+
+      expect(subscriptions.data.first.id).to eq(subscription_schedule.subscription)
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(subscriptions.data.first.billing).to eq('charge_automatically')
     end
   end
 end


### PR DESCRIPTION
## Description
Creating a subscription schedule properly sets the customer on the resulting subscription
