### PR TITLE
Add void invoice to supported invoice calls

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -9,6 +9,7 @@ module StripeMock
         klass.add_handler 'get /v1/invoices/(.*)',           :get_invoice
         klass.add_handler 'get /v1/invoices',                :list_invoices
         klass.add_handler 'post /v1/invoices/(.*)/pay',      :pay_invoice
+        klass.add_handler 'post /v1/invoices/(.*)/void',     :void_invoice
         klass.add_handler 'post /v1/invoices/(.*)',          :update_invoice
       end
 
@@ -149,6 +150,13 @@ module StripeMock
           period_start: prorating ? invoice_date : preview_subscription[:current_period_start],
           period_end: prorating ? invoice_date : preview_subscription[:current_period_end],
           next_payment_attempt: preview_subscription[:current_period_end] + 3600 )
+      end
+
+      def void_invoice(route, method_url, params, headers)
+        route =~ method_url
+        assert_existence :invoice, $1, invoices[$1]
+        void_params = params.merge(status: 'void')
+        invoices[$1].merge!(void_params)
       end
 
       private

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -40,6 +40,19 @@ shared_examples 'Invoice API' do
     end
   end
 
+  context "voiding an invoice" do
+    it "updates the status of an invoice to 'void'" do
+      invoice = Stripe::Invoice.create
+      invoice.save
+      expect(invoice.status).to eq("open")
+
+      Stripe::Invoice.void_invoice(invoice.id)
+
+      updated_invoice = Stripe::Invoice.retrieve(invoice.id)
+      expect(updated_invoice.status).to eq("void")
+    end
+  end
+
   context "retrieving a list of invoices" do
     before do
       @customer = Stripe::Customer.create(email: 'johnny@appleseed.com')


### PR DESCRIPTION
## Description

Support the stripe [void_invoice method](https://stripe.com/docs/api/invoices/void)